### PR TITLE
feat(aws): aws s3 upload retries

### DIFF
--- a/util/cloud/CMakeLists.txt
+++ b/util/cloud/CMakeLists.txt
@@ -1,6 +1,6 @@
 find_package(LibXml2)
 
-add_library(aws_lib aws.cc s3.cc s3_file.cc)
+add_library(aws_lib aws.cc s3.cc s3_file.cc client.cc)
 
 cxx_link(aws_lib base OpenSSL::Crypto TRDP::rapidjson http_utils 
          TRDP::pugixml http_client_lib)

--- a/util/cloud/client.cc
+++ b/util/cloud/client.cc
@@ -1,0 +1,27 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+
+#include "util/cloud/client.h"
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+namespace util {
+namespace cloud {
+
+Client::Client(const AWS* aws, http::Client* http_client) : aws_{aws}, client_{http_client} {
+  sign_key_ = aws_->GetSignKey(aws_->connection_data().region);
+}
+
+void Client::RetryBackoff(int attempt) const {
+  if (attempt <= 1) {
+    return;
+  }
+
+  // TODO(andydunstall) Hard code for now
+  ThisFiber::SleepFor(5s);
+}
+
+}  // namespace cloud
+}  // namespace util

--- a/util/cloud/client.h
+++ b/util/cloud/client.h
@@ -1,0 +1,177 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+
+#pragma once
+
+#include <boost/beast/http/message.hpp>
+#include <pugixml.hpp>
+#include <system_error>
+
+#include "base/logging.h"
+#include "util/cloud/aws.h"
+#include "util/fibers/proactor_base.h"
+#include "util/http/http_client.h"
+
+namespace util {
+namespace cloud {
+
+namespace h2 = boost::beast::http;
+
+class Client {
+ public:
+  Client(const AWS* aws, http::Client* http_client);
+
+  template <typename Req, typename Resp> std::error_code Request(Req* req, Resp* resp);
+
+ private:
+  template <typename Req> std::error_code ConnectIfNeeded(Req* req);
+
+  template <typename Resp> io::Result<std::string> ParseErrorCode(Resp* resp) const;
+
+  void RetryBackoff(int attempt) const;
+
+  const AWS* aws_;
+
+  http::Client* client_;
+
+  AwsSignKey sign_key_;
+
+  bool reconnect_ = false;
+};
+
+template <typename Req, typename Resp> std::error_code Client::Request(Req* req, Resp* resp) {
+  std::error_code ec;
+
+  int attempt = 0;
+  while (true) {
+    attempt++;
+
+    RetryBackoff(attempt);
+
+    if (attempt > 5) {
+      return ec;
+    }
+
+    ec = ConnectIfNeeded(req);
+    if (ec) {
+      continue;
+    }
+
+    // Resign on each retry since the credentials may have been updated.
+    // TODO(andydunstall) Only support empty or unsigned payload.
+    boost::optional<std::uint64_t> payload_size = req->payload_size();
+    if (payload_size && *payload_size == 0) {
+      sign_key_.Sign(AWS::kEmptySig, req);
+    } else {
+      sign_key_.Sign(AWS::kUnsignedPayloadSig, req);
+    }
+
+    absl::Time attempt_time = absl::Now();
+    DVLOG(3) << "aws client: send request: (attempt = " << attempt << ", "
+             << "attempt_time = " << attempt_time << ")" << std::endl
+             << "-------------------------" << std::endl
+             << *req << "-------------------------";
+
+    ec = client_->Send(*req, resp);
+    if (ec) {
+      DVLOG(1) << "aws client: failed to send request; error=" << ec;
+      // If we failed to send the request we reconnect.
+      // TODO(andydunstall) AWS::SendRequest only reconnects if it gets
+      // boost::system::errc::connection_aborted.
+      reconnect_ = true;
+      continue;
+    }
+
+    DVLOG(3) << "aws client: recv response: " << std::endl
+             << "-------------------------" << std::endl
+             << *resp << "-------------------------";
+
+    auto& headers = resp->base();
+    if (headers[h2::field::connection] == "close") {
+      reconnect_ = true;
+    }
+
+    // TODO(andydunstall) Incorrectly getting OK after a disconnect (with no
+    // body)
+    if (resp->result() == h2::status::ok) {
+      return std::error_code{};
+    }
+
+    io::Result<std::string> error_code = ParseErrorCode(resp);
+    if (!error_code) {
+      // If we can't parse the error, retry anyway.
+      LOG(WARNING) << "aws client: failed to parse error code in non-200 response";
+      continue;
+    }
+
+    if (*error_code == "ExpiredToken" || *error_code == "ExpiredTokenException") {
+      VLOG(1) << "aws client: expired credentials; refreshing credentials";
+      aws_->RefreshToken();
+      sign_key_ = aws_->GetSignKey(aws_->connection_data().region);
+      continue;
+    }
+
+    // TODO(andydunstall) Handle other errors...
+  }
+
+  return std::error_code{};
+}
+
+template <typename Req> std::error_code Client::ConnectIfNeeded(Req* req) {
+  if (!reconnect_) {
+    return std::error_code{};
+  }
+
+  auto host_it = req->find(h2::field::host);
+  if (host_it == req->end()) {
+    LOG(WARNING) << "aws client: request: missing host header";
+    return std::make_error_code(std::errc::invalid_argument);
+  }
+
+  std::string host = host_it->value();
+  std::string port;
+
+  size_t pos = host.rfind(':');
+  if (pos != std::string::npos) {
+    port = host.substr(pos + 1);
+    host = host.substr(0, pos);
+  } else {
+    port = "80";
+  }
+
+  DVLOG(1) << "aws client: reconnecting; host=" << host << "; port=" << port;
+
+  std::error_code ec = client_->Connect(host, port);
+  if (ec) {
+    LOG(WARNING) << "aws client: request: failed to connect; host=" << host << "; error=" << ec;
+    return ec;
+  }
+
+  reconnect_ = false;
+
+  return std::error_code{};
+}
+
+template <typename Resp> io::Result<std::string> Client::ParseErrorCode(Resp* resp) const {
+  // We only support S3 so assume XML.
+  pugi::xml_document doc;
+  pugi::xml_parse_result result = doc.load_buffer(resp->body().data(), resp->body().size());
+  if (!result) {
+    LOG(ERROR) << "aws client: failed to parse xml response: " << result.description();
+    return nonstd::make_unexpected(std::make_error_code(std::errc::bad_message));
+  }
+  pugi::xml_node root = doc.child("Error");
+  if (root.type() != pugi::node_element) {
+    LOG(ERROR) << "aws client: failed to parse error code";
+    return nonstd::make_unexpected(std::make_error_code(std::errc::bad_message));
+  }
+  std::string code = root.child("Code").text().get();
+  if (code.empty()) {
+    LOG(ERROR) << "aws client: failed to parse error code";
+    return nonstd::make_unexpected(std::make_error_code(std::errc::bad_message));
+  }
+  return code;
+}
+
+}  // namespace cloud
+}  // namespace util


### PR DESCRIPTION
Adds client retries and error handling for more reliable S3 uploads

# Changes

## `cloud::Client`
`cloud::Client` is a HTTP client for AWS that handles signing requests, error handling and retries with backoff. This avoids every caller having to decide on its own retry strategy.

I can't find any docs on how AWS expects retries to work, so this is based on the Go SDK. It doesn't yet exactly match the AWS SDKs retry and error handling, though is hopefully an improvement.

### Authentication
...

### Retries
See https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ErrorCodeList
...

## Missing
- Redirect support
- ...

# Testing
Testing retries locally by proxying HTTP traffic with toxiproxy, then running large uploads through the proxy. Limitting the proxy throughput to slow down the upload, then periodically terminating the proxy connection for a few seconds to verify the client reconnects and continues uploading.

Also creating a Dragonfly instance with 100GB of random memory, then writing a script to keep uploading a snapshot on repeat. Note uploads in the same region to S3 are free and using a fixed file path so storage costs are negligible. This should test more realistic issues like token expiry.
