### PR TITLE
feat(aws): aws sdk poc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ else()
   include(internal)
 endif()
 
+set(AWS_SERVICE_COMPONENTS s3)
+find_package(AWSSDK REQUIRED COMPONENTS ${AWS_SERVICE_COMPONENTS})
 
 add_definitions(-DUSE_FB2)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -15,7 +15,7 @@ add_executable(s3_demo s3_demo.cc)
 cxx_link(s3_demo aws_lib)
 
 add_executable(s3v2_demo s3v2_demo.cc)
-cxx_link(s3v2_demo awsv2_lib)
+cxx_link(s3v2_demo awsv2_lib awss3_lib)
 
 add_executable(https_client_cli https_client_cli.cc)
 cxx_link(https_client_cli base fibers2 http_client_lib tls_lib)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -15,7 +15,7 @@ add_executable(s3_demo s3_demo.cc)
 cxx_link(s3_demo aws_lib)
 
 add_executable(s3v2_demo s3v2_demo.cc)
-cxx_link(s3v2_demo awsv2_lib ${AWSSDK_LINK_LIBRARIES})
+cxx_link(s3v2_demo awsv2_lib)
 
 add_executable(https_client_cli https_client_cli.cc)
 cxx_link(https_client_cli base fibers2 http_client_lib tls_lib)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -14,5 +14,8 @@ cxx_link(echo_server base fibers2 http_server_lib TRDP::gperf)
 add_executable(s3_demo s3_demo.cc)
 cxx_link(s3_demo aws_lib)
 
+add_executable(s3v2_demo s3v2_demo.cc)
+cxx_link(s3v2_demo awsv2_lib ${AWSSDK_LINK_LIBRARIES})
+
 add_executable(https_client_cli https_client_cli.cc)
 cxx_link(https_client_cli base fibers2 http_client_lib tls_lib)

--- a/examples/s3v2_demo.cc
+++ b/examples/s3v2_demo.cc
@@ -1,0 +1,9 @@
+#include <aws/core/auth/AWSCredentialsProvider.h>
+
+#include "base/logging.h"
+
+int main() {
+  Aws::Auth::EnvironmentAWSCredentialsProvider provider{};
+  Aws::Auth::AWSCredentials creds = provider.GetAWSCredentials();
+  LOG(INFO) << "access key id " << creds.GetAWSAccessKeyId();
+}

--- a/examples/s3v2_demo.cc
+++ b/examples/s3v2_demo.cc
@@ -3,6 +3,7 @@
 
 #include <aws/core/auth/AWSCredentialsProvider.h>
 #include <aws/s3/S3Client.h>
+#include <aws/s3/model/ListObjectsV2Request.h>
 
 #include <memory>
 
@@ -13,25 +14,7 @@
 
 ABSL_FLAG(bool, epoll, false, "Whether to use epoll instead of io_uring");
 
-int main(int argc, char* argv[]) {
-  MainInitGuard guard(&argc, &argv);
-
-  std::unique_ptr<util::ProactorPool> pp;
-
-#ifdef __linux__
-  if (absl::GetFlag(FLAGS_epoll)) {
-    pp.reset(util::fb2::Pool::Epoll());
-  } else {
-    pp.reset(util::fb2::Pool::IOUring(256));
-  }
-#else
-  pp.reset(util::fb2::Pool::Epoll());
-#endif
-
-  pp->Run();
-
-  util::cloud::aws::Init();
-
+void ListBuckets() {
   Aws::S3::S3ClientConfiguration s3_conf{};
   // Out HTTP client currently only supports HTTP.
   s3_conf.scheme = Aws::Http::Scheme::HTTP;
@@ -53,6 +36,58 @@ int main(int argc, char* argv[]) {
   } else {
     LOG(ERROR) << "failed to list buckets: " << outcome.GetError().GetExceptionName();
   }
+}
 
-  util::cloud::aws::Shutdown();
+void ListObjects() {
+  Aws::S3::S3ClientConfiguration s3_conf{};
+  // Out HTTP client currently only supports HTTP.
+  s3_conf.scheme = Aws::Http::Scheme::HTTP;
+  // HTTP 1.1 is the latest version our HTTP client supports.
+  s3_conf.version = Aws::Http::Version::HTTP_VERSION_1_1;
+
+  // TODO(andydunstall) For now only support the environment provider.
+  std::shared_ptr<Aws::Auth::AWSCredentialsProvider> credentials_provider =
+      Aws::MakeShared<Aws::Auth::EnvironmentAWSCredentialsProvider>("helio");
+  Aws::S3::S3Client s3{credentials_provider, Aws::MakeShared<Aws::S3::S3EndpointProvider>("helio"),
+                       s3_conf};
+
+  Aws::S3::Model::ListObjectsV2Request list_objects_request;
+  list_objects_request.SetBucket("dev-andy-dfcloud-backups-us-east-1");
+
+  Aws::S3::Model::ListObjectsV2Outcome outcome = s3.ListObjectsV2(list_objects_request);
+  if (outcome.IsSuccess()) {
+    std::cout << "objects: " << std::endl;
+    for (const auto& object : outcome.GetResult().GetContents()) {
+      std::cout << object.GetKey() << std::endl;
+    }
+  } else {
+    LOG(ERROR) << "failed to list objects: " << outcome.GetError().GetExceptionName();
+  }
+}
+
+int main(int argc, char* argv[]) {
+  MainInitGuard guard(&argc, &argv);
+
+  std::unique_ptr<util::ProactorPool> pp;
+
+#ifdef __linux__
+  if (absl::GetFlag(FLAGS_epoll)) {
+    pp.reset(util::fb2::Pool::Epoll());
+  } else {
+    pp.reset(util::fb2::Pool::IOUring(256));
+  }
+#else
+  pp.reset(util::fb2::Pool::Epoll());
+#endif
+
+  pp->Run();
+
+  pp->GetNextProactor()->Await([&] {
+    util::cloud::aws::Init();
+
+    // ListBuckets();
+    ListObjects();
+
+    util::cloud::aws::Shutdown();
+  });
 }

--- a/examples/s3v2_demo.cc
+++ b/examples/s3v2_demo.cc
@@ -1,6 +1,9 @@
 // Copyright 2023, Roman Gershman.  All rights reserved.
 // See LICENSE for licensing terms.
 
+#include <aws/core/auth/AWSCredentialsProvider.h>
+#include <aws/s3/S3Client.h>
+
 #include <memory>
 
 #include "base/init.h"
@@ -28,6 +31,28 @@ int main(int argc, char* argv[]) {
   pp->Run();
 
   util::cloud::aws::Init();
+
+  Aws::S3::S3ClientConfiguration s3_conf{};
+  // Out HTTP client currently only supports HTTP.
+  s3_conf.scheme = Aws::Http::Scheme::HTTP;
+  // HTTP 1.1 is the latest version our HTTP client supports.
+  s3_conf.version = Aws::Http::Version::HTTP_VERSION_1_1;
+
+  // TODO(andydunstall) For now only support the environment provider.
+  std::shared_ptr<Aws::Auth::AWSCredentialsProvider> credentials_provider =
+      Aws::MakeShared<Aws::Auth::EnvironmentAWSCredentialsProvider>("helio");
+  Aws::S3::S3Client s3{credentials_provider, Aws::MakeShared<Aws::S3::S3EndpointProvider>("helio"),
+                       s3_conf};
+
+  Aws::S3::Model::ListBucketsOutcome outcome = s3.ListBuckets();
+  if (outcome.IsSuccess()) {
+    std::cout << "buckets: " << std::endl;
+    for (const Aws::S3::Model::Bucket& bucket : outcome.GetResult().GetBuckets()) {
+      std::cout << bucket.GetName() << std::endl;
+    }
+  } else {
+    LOG(ERROR) << "failed to list buckets: " << outcome.GetError().GetExceptionName();
+  }
 
   util::cloud::aws::Shutdown();
 }

--- a/examples/s3v2_demo.cc
+++ b/examples/s3v2_demo.cc
@@ -1,9 +1,33 @@
-#include <aws/core/auth/AWSCredentialsProvider.h>
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
 
+#include <memory>
+
+#include "base/init.h"
 #include "base/logging.h"
+#include "util/cloud/aws/aws.h"
+#include "util/fibers/pool.h"
 
-int main() {
-  Aws::Auth::EnvironmentAWSCredentialsProvider provider{};
-  Aws::Auth::AWSCredentials creds = provider.GetAWSCredentials();
-  LOG(INFO) << "access key id " << creds.GetAWSAccessKeyId();
+ABSL_FLAG(bool, epoll, false, "Whether to use epoll instead of io_uring");
+
+int main(int argc, char* argv[]) {
+  MainInitGuard guard(&argc, &argv);
+
+  std::unique_ptr<util::ProactorPool> pp;
+
+#ifdef __linux__
+  if (absl::GetFlag(FLAGS_epoll)) {
+    pp.reset(util::fb2::Pool::Epoll());
+  } else {
+    pp.reset(util::fb2::Pool::IOUring(256));
+  }
+#else
+  pp.reset(util::fb2::Pool::Epoll());
+#endif
+
+  pp->Run();
+
+  util::cloud::aws::Init();
+
+  util::cloud::aws::Shutdown();
 }

--- a/util/cloud/CMakeLists.txt
+++ b/util/cloud/CMakeLists.txt
@@ -4,3 +4,5 @@ add_library(aws_lib aws.cc s3.cc s3_file.cc)
 
 cxx_link(aws_lib base OpenSSL::Crypto TRDP::rapidjson http_utils 
          TRDP::pugixml http_client_lib)
+
+add_subdirectory(aws)

--- a/util/cloud/aws/CMakeLists.txt
+++ b/util/cloud/aws/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_library(awsv2_lib aws.cc http_client.cc http_client_factory.cc)
 
 cxx_link(awsv2_lib base http_utils http_client_lib ${AWSSDK_LINK_LIBRARIES})
+
+add_subdirectory(s3)

--- a/util/cloud/aws/CMakeLists.txt
+++ b/util/cloud/aws/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_library(awsv2_lib aws.cc http_client_factory.cc)
+add_library(awsv2_lib aws.cc http_client.cc http_client_factory.cc)
 
 cxx_link(awsv2_lib base http_utils http_client_lib ${AWSSDK_LINK_LIBRARIES})

--- a/util/cloud/aws/CMakeLists.txt
+++ b/util/cloud/aws/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(awsv2_lib aws.cc)
+
+cxx_link(awsv2_lib base)

--- a/util/cloud/aws/CMakeLists.txt
+++ b/util/cloud/aws/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_library(awsv2_lib aws.cc)
+add_library(awsv2_lib aws.cc http_client_factory.cc)
 
-cxx_link(awsv2_lib base)
+cxx_link(awsv2_lib base http_utils http_client_lib ${AWSSDK_LINK_LIBRARIES})

--- a/util/cloud/aws/aws.cc
+++ b/util/cloud/aws/aws.cc
@@ -1,8 +1,46 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+
 #include "util/cloud/aws/aws.h"
+
+#include <aws/core/Aws.h>
+
+#include "util/cloud/aws/http_client_factory.h"
 
 namespace util {
 namespace cloud {
 namespace aws {
+
+namespace {
+
+// Required by both Init and Shutdown so make static.
+static Aws::SDKOptions options;
+
+}  // namespace
+
+void Init() {
+  // TODO(andydunstall): Configure logging. Use a custom glog based logger?
+  options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Debug;
+
+  // Disable starting the background IO event loop thread which we don't need.
+  options.ioOptions.clientBootstrap_create_fn =
+      []() -> std::shared_ptr<Aws::Crt::Io::ClientBootstrap> { return nullptr; };
+
+  // We must use non-blocking network IO so use our own fiber based HTTP client.
+  options.httpOptions.httpClientFactory_create_fn =
+      []() -> std::shared_ptr<Aws::Http::HttpClientFactory> {
+    return Aws::MakeShared<util::cloud::aws::HttpClientFactory>("helio");
+  };
+
+  // We don't use cURL so don't initialise or cleanup.
+  options.httpOptions.initAndCleanupCurl = false;
+
+  Aws::InitAPI(options);
+}
+
+void Shutdown() {
+  Aws::ShutdownAPI(options);
+}
 
 }  // namespace aws
 }  // namespace cloud

--- a/util/cloud/aws/aws.cc
+++ b/util/cloud/aws/aws.cc
@@ -1,0 +1,9 @@
+#include "util/cloud/aws/aws.h"
+
+namespace util {
+namespace cloud {
+namespace aws {
+
+}  // namespace aws
+}  // namespace cloud
+}  // namespace util

--- a/util/cloud/aws/aws.h
+++ b/util/cloud/aws/aws.h
@@ -1,11 +1,17 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+
 #pragma once
 
 namespace util {
 namespace cloud {
 namespace aws {
 
-class Aws {
-};
+// Initialises the AWS library. This must be called before using any AWS
+// services.
+void Init();
+
+void Shutdown();
 
 }  // namespace aws
 }  // namespace cloud

--- a/util/cloud/aws/aws.h
+++ b/util/cloud/aws/aws.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace util {
+namespace cloud {
+namespace aws {
+
+class Aws {
+};
+
+}  // namespace aws
+}  // namespace cloud
+}  // namespace util

--- a/util/cloud/aws/http_client.cc
+++ b/util/cloud/aws/http_client.cc
@@ -1,0 +1,39 @@
+#include "util/cloud/aws/http_client.h"
+
+namespace util {
+namespace cloud {
+namespace aws {
+
+std::shared_ptr<Aws::Http::HttpResponse> HttpClient::MakeRequest(
+    const std::shared_ptr<Aws::Http::HttpRequest>& request,
+    Aws::Utils::RateLimits::RateLimiterInterface* readLimiter,
+    Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter) const {
+  // TODO(andydunstall)
+  return nullptr;
+}
+
+void HttpClient::DisableRequestProcessing() {
+  // TODO(andydunstall)
+}
+
+void HttpClient::EnableRequestProcessing() {
+  // TODO(andydunstall)
+}
+
+bool HttpClient::IsRequestProcessingEnabled() const {
+  // TODO(andydunstall)
+  return true;
+}
+
+bool HttpClient::ContinueRequest(const Aws::Http::HttpRequest&) const {
+  // TODO(andydunstall)
+  return true;
+}
+
+void HttpClient::RetryRequestSleep(std::chrono::milliseconds sleepTime) {
+  // TODO(andydunstall)
+}
+
+}  // namespace aws
+}  // namespace cloud
+}  // namespace util

--- a/util/cloud/aws/http_client.cc
+++ b/util/cloud/aws/http_client.cc
@@ -153,8 +153,8 @@ bool HttpClient::ContinueRequest(const Aws::Http::HttpRequest&) const {
 }
 
 void HttpClient::RetryRequestSleep(std::chrono::milliseconds sleepTime) {
-  // TODO(andydunstall) Add an arbitrary sleep for now
-  ThisFiber::SleepFor(5s);
+  // TODO(andydunstall): Handle disable request processing
+  ThisFiber::SleepFor(sleepTime);
 }
 
 }  // namespace aws

--- a/util/cloud/aws/http_client.cc
+++ b/util/cloud/aws/http_client.cc
@@ -1,15 +1,124 @@
 #include "util/cloud/aws/http_client.h"
 
+#include <aws/core/http/HttpRequest.h>
+#include <aws/core/http/standard/StandardHttpResponse.h>
+
+#include <boost/beast/http/empty_body.hpp>
+#include <boost/beast/http/message.hpp>
+#include <boost/beast/http/string_body.hpp>
+
+#include "base/logging.h"
+#include "util/fibers/proactor_base.h"
+
 namespace util {
 namespace cloud {
 namespace aws {
+
+namespace h2 = boost::beast::http;
+
+using namespace std::chrono_literals;
+
+namespace {
+
+h2::verb AwsMethodToBoost(Aws::Http::HttpMethod method) {
+  switch (method) {
+    case Aws::Http::HttpMethod::HTTP_GET:
+      return h2::verb::get;
+    case Aws::Http::HttpMethod::HTTP_POST:
+      return h2::verb::post;
+    case Aws::Http::HttpMethod::HTTP_DELETE:
+      return h2::verb::delete_;
+    case Aws::Http::HttpMethod::HTTP_PUT:
+      return h2::verb::put;
+    case Aws::Http::HttpMethod::HTTP_HEAD:
+      return h2::verb::head;
+    case Aws::Http::HttpMethod::HTTP_PATCH:
+      return h2::verb::patch;
+    default:
+      LOG(ERROR) << "aws: http client: invalid http method: " << static_cast<int>(method);
+      return h2::verb::unknown;
+  }
+}
+
+}  // namespace
+
+HttpClient::HttpClient() {
+  ProactorBase* proactor = ProactorBase::me();
+  CHECK(proactor) << "must run in a proactor thread";
+  http_client_ = std::make_unique<http::Client>(proactor);
+}
 
 std::shared_ptr<Aws::Http::HttpResponse> HttpClient::MakeRequest(
     const std::shared_ptr<Aws::Http::HttpRequest>& request,
     Aws::Utils::RateLimits::RateLimiterInterface* readLimiter,
     Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter) const {
+  // TODO(andydunstall) Why is S3 using HTTPS when HTTP was configured
+  if (request->GetUri().GetScheme() != Aws::Http::Scheme::HTTP) {
+    LOG(WARNING) << "only http is supported";
+    // TODO(andydunstall) For now just update to http
+    request->GetUri().SetScheme(Aws::Http::Scheme::HTTP);
+    if (request->GetUri().GetPort() == 443) {
+      request->GetUri().SetPort(80);
+    }
+  }
+
+  // TODO(andydunstall): Check rate limitter
+
+  const h2::verb method = AwsMethodToBoost(request->GetMethod());
+
+  DVLOG(2) << "aws: http client: request; method=" << h2::to_string(method)
+           << "; url=" << request->GetUri().GetURIString();
+  for (const auto& h : request->GetHeaders()) {
+    DVLOG(2) << "aws: http client: request; header=" << h.first << "=" << h.second;
+  }
+
+  // TODO(andydunstall): Verify HTTP version
+  // TODO(andydunstall): Support non-empty body
+  h2::request<h2::empty_body> req{method, request->GetUri().GetURIString(), 11};
+  for (const auto& h : request->GetHeaders()) {
+    req.set(h.first, h.second);
+  }
+
+  std::shared_ptr<Aws::Http::HttpResponse> response =
+      Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>("helio", request);
+
+  // TODO(andydunstall): HTTP client should automatically connect if its not
+  // already connected. It MUST also support connecting to multiple addresses
+  // from the same client (such as when redirected)
+
+  // TODO(andydunstall): Hard code 80 for now
+  auto ec = http_client_->Connect(request->GetUri().GetAuthority(), "80");
+  if (ec) {
+    LOG(WARNING) << "aws: http client: failed to connect: " << request->GetUri().GetAuthority()
+                 << ": " << ec;
+
+    // TODO(andydunstall): Handle appropriately
+    response->SetClientErrorType(Aws::Client::CoreErrors::NETWORK_CONNECTION);
+    return response;
+  }
+
+  h2::response<h2::string_body> resp;
+  ec = http_client_->Send(req, &resp);
+  if (ec) {
+    LOG(WARNING) << "aws: http client: failed to send request: " << ec;
+    response->SetClientErrorType(Aws::Client::CoreErrors::NETWORK_CONNECTION);
+    return response;
+  }
+
+  response->SetResponseCode(static_cast<Aws::Http::HttpResponseCode>(resp.result_int()));
+  for (const auto& h : resp.base()) {
+    response->AddHeader(h.name_string(), h.value());
+  }
+  response->GetResponseBody().write(resp.body().data(), resp.body().size());
+
+  DVLOG(2) << "aws: http client: response; status=" << resp.result_int();
+  for (const auto& h : response->GetHeaders()) {
+    DVLOG(2) << "aws: http client: response; header=" << h.first << "=" << h.second;
+  }
+
   // TODO(andydunstall)
-  return nullptr;
+
+  return response;
 }
 
 void HttpClient::DisableRequestProcessing() {
@@ -31,7 +140,8 @@ bool HttpClient::ContinueRequest(const Aws::Http::HttpRequest&) const {
 }
 
 void HttpClient::RetryRequestSleep(std::chrono::milliseconds sleepTime) {
-  // TODO(andydunstall)
+  // TODO(andydunstall) Add an arbitrary sleep for now
+  ThisFiber::SleepFor(5s);
 }
 
 }  // namespace aws

--- a/util/cloud/aws/http_client.h
+++ b/util/cloud/aws/http_client.h
@@ -1,0 +1,32 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+
+#pragma once
+
+#include <aws/core/http/HttpClient.h>
+
+namespace util {
+namespace cloud {
+namespace aws {
+
+class HttpClient : public Aws::Http::HttpClient {
+ public:
+  std::shared_ptr<Aws::Http::HttpResponse> MakeRequest(
+      const std::shared_ptr<Aws::Http::HttpRequest>& request,
+      Aws::Utils::RateLimits::RateLimiterInterface* readLimiter = nullptr,
+      Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter = nullptr) const override;
+
+  void DisableRequestProcessing() override;
+
+  void EnableRequestProcessing() override;
+
+  bool IsRequestProcessingEnabled() const override;
+
+  bool ContinueRequest(const Aws::Http::HttpRequest&) const override;
+
+  void RetryRequestSleep(std::chrono::milliseconds sleepTime) override;
+};
+
+}  // namespace aws
+}  // namespace cloud
+}  // namespace util

--- a/util/cloud/aws/http_client.h
+++ b/util/cloud/aws/http_client.h
@@ -5,12 +5,18 @@
 
 #include <aws/core/http/HttpClient.h>
 
+#include <memory>
+
+#include "util/http/http_client.h"
+
 namespace util {
 namespace cloud {
 namespace aws {
 
 class HttpClient : public Aws::Http::HttpClient {
  public:
+  HttpClient();
+
   std::shared_ptr<Aws::Http::HttpResponse> MakeRequest(
       const std::shared_ptr<Aws::Http::HttpRequest>& request,
       Aws::Utils::RateLimits::RateLimiterInterface* readLimiter = nullptr,
@@ -25,6 +31,9 @@ class HttpClient : public Aws::Http::HttpClient {
   bool ContinueRequest(const Aws::Http::HttpRequest&) const override;
 
   void RetryRequestSleep(std::chrono::milliseconds sleepTime) override;
+
+ private:
+  std::unique_ptr<http::Client> http_client_;
 };
 
 }  // namespace aws

--- a/util/cloud/aws/http_client_factory.cc
+++ b/util/cloud/aws/http_client_factory.cc
@@ -3,28 +3,29 @@
 
 #include "util/cloud/aws/http_client_factory.h"
 
+#include "util/cloud/aws/http_client.h"
+
 namespace util {
 namespace cloud {
 namespace aws {
 
 std::shared_ptr<Aws::Http::HttpClient> HttpClientFactory::CreateHttpClient(
     const Aws::Client::ClientConfiguration& clientConfiguration) const {
-  // TODO(andydunstall)
-  return nullptr;
+  return Aws::MakeShared<HttpClient>("helio");
 }
 
 std::shared_ptr<Aws::Http::HttpRequest> HttpClientFactory::CreateHttpRequest(
     const Aws::String& uri, Aws::Http::HttpMethod method,
     const Aws::IOStreamFactory& streamFactory) const {
-  // TODO(andydunstall)
-  return nullptr;
+  return CreateHttpRequest(Aws::Http::URI(uri), method, streamFactory);
 }
 
 std::shared_ptr<Aws::Http::HttpRequest> HttpClientFactory::CreateHttpRequest(
     const Aws::Http::URI& uri, Aws::Http::HttpMethod method,
     const Aws::IOStreamFactory& streamFactory) const {
-  // TODO(andydunstall)
-  return nullptr;
+  auto request = Aws::MakeShared<Aws::Http::Standard::StandardHttpRequest>("helio", uri, method);
+  request->SetResponseStreamFactory(streamFactory);
+  return request;
 }
 
 }  // namespace aws

--- a/util/cloud/aws/http_client_factory.cc
+++ b/util/cloud/aws/http_client_factory.cc
@@ -1,0 +1,32 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+
+#include "util/cloud/aws/http_client_factory.h"
+
+namespace util {
+namespace cloud {
+namespace aws {
+
+std::shared_ptr<Aws::Http::HttpClient> HttpClientFactory::CreateHttpClient(
+    const Aws::Client::ClientConfiguration& clientConfiguration) const {
+  // TODO(andydunstall)
+  return nullptr;
+}
+
+std::shared_ptr<Aws::Http::HttpRequest> HttpClientFactory::CreateHttpRequest(
+    const Aws::String& uri, Aws::Http::HttpMethod method,
+    const Aws::IOStreamFactory& streamFactory) const {
+  // TODO(andydunstall)
+  return nullptr;
+}
+
+std::shared_ptr<Aws::Http::HttpRequest> HttpClientFactory::CreateHttpRequest(
+    const Aws::Http::URI& uri, Aws::Http::HttpMethod method,
+    const Aws::IOStreamFactory& streamFactory) const {
+  // TODO(andydunstall)
+  return nullptr;
+}
+
+}  // namespace aws
+}  // namespace cloud
+}  // namespace util

--- a/util/cloud/aws/http_client_factory.h
+++ b/util/cloud/aws/http_client_factory.h
@@ -1,0 +1,32 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+
+#pragma once
+
+#include <aws/core/http/HttpClientFactory.h>
+#include <aws/core/http/URI.h>
+#include <aws/core/http/standard/StandardHttpRequest.h>
+
+#include <memory>
+
+namespace util {
+namespace cloud {
+namespace aws {
+
+class HttpClientFactory : public Aws::Http::HttpClientFactory {
+ public:
+  std::shared_ptr<Aws::Http::HttpClient> CreateHttpClient(
+      const Aws::Client::ClientConfiguration& clientConfiguration) const override;
+
+  std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(
+      const Aws::String& uri, Aws::Http::HttpMethod method,
+      const Aws::IOStreamFactory& streamFactory) const override;
+
+  std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(
+      const Aws::Http::URI& uri, Aws::Http::HttpMethod method,
+      const Aws::IOStreamFactory& streamFactory) const override;
+};
+
+}  // namespace aws
+}  // namespace cloud
+}  // namespace util

--- a/util/cloud/aws/s3/CMakeLists.txt
+++ b/util/cloud/aws/s3/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(awss3_lib write_file.cc)
+
+cxx_link(awss3_lib base ${AWSSDK_LINK_LIBRARIES})

--- a/util/cloud/aws/s3/write_file.cc
+++ b/util/cloud/aws/s3/write_file.cc
@@ -1,0 +1,135 @@
+#include "util/cloud/aws/s3/write_file.h"
+
+#include <aws/s3/model/CompleteMultipartUploadRequest.h>
+#include <aws/s3/model/CompletedMultipartUpload.h>
+#include <aws/s3/model/CreateMultipartUploadRequest.h>
+#include <aws/s3/model/UploadPartRequest.h>
+
+#include "base/logging.h"
+
+namespace util {
+namespace cloud {
+namespace aws {
+namespace s3 {
+
+constexpr size_t kPartSize = 10 * (1 << 20);
+
+WriteFile::WriteFile(const std::string& bucket, const std::string& key,
+                     const std::string& upload_id, Aws::S3::S3Client* client)
+    : io::WriteFile{""}, bucket_{bucket}, key_{key}, upload_id_{upload_id},
+      buf_(kPartSize), client_{client} {
+}
+
+io::Result<size_t> WriteFile::WriteSome(const iovec* v, uint32_t len) {
+  size_t total = 0;
+  for (size_t i = 0; i < len; ++i) {
+    const char* buf = reinterpret_cast<const char*>(v[i].iov_base);
+    const size_t len = v[i].iov_len;
+
+    size_t written = 0;
+    while (written < len) {
+      size_t n = len - written;
+      if (n > buf_.size() - offset_) {
+        n = buf_.size() - offset_;
+      }
+      memcpy(buf_.data() + offset_, buf + written, n);
+      written += n;
+      total += n;
+      offset_ += n;
+
+      if (buf_.size() == offset_) {
+        std::error_code ec = Upload();
+        if (ec) {
+          return nonstd::make_unexpected(ec);
+        }
+      }
+    }
+  }
+
+  return total;
+}
+
+std::error_code WriteFile::Close() {
+  std::error_code ec = Upload();
+  if (ec) {
+    return ec;
+  }
+
+  Aws::S3::Model::CompletedMultipartUpload completed_upload;
+  for (size_t i = 0; i != parts_.size(); i++) {
+    Aws::S3::Model::CompletedPart part;
+    part.SetPartNumber(i + 1);
+    part.SetETag(parts_[i]);
+    completed_upload.AddParts(part);
+  }
+
+  Aws::S3::Model::CompleteMultipartUploadRequest request;
+  request.SetBucket(bucket_);
+  request.SetKey(key_);
+  request.SetUploadId(upload_id_);
+  request.SetMultipartUpload(completed_upload);
+
+  Aws::S3::Model::CompleteMultipartUploadOutcome outcome =
+      client_->CompleteMultipartUpload(request);
+  if (outcome.IsSuccess()) {
+    LOG(INFO) << "completed multipart upload";
+  } else {
+    LOG(ERROR) << "failed to complete multipart upload: " << outcome.GetError().GetExceptionName();
+    return std::make_error_code(std::errc::io_error);
+  }
+
+  return std::error_code{};
+}
+
+std::error_code WriteFile::Upload() {
+  if (offset_ == 0) {
+    return std::error_code{};
+  }
+
+  Aws::S3::Model::UploadPartRequest request;
+  request.SetBucket(bucket_);
+  request.SetKey(key_);
+  // TODO(andydunstall)
+  request.SetPartNumber(parts_.size() + 1);
+  request.SetUploadId(upload_id_);
+
+  // TODO(andydunstall): Look at avoiding this copy
+  std::shared_ptr<Aws::IOStream> object_stream = Aws::MakeShared<Aws::StringStream>("helio");
+  object_stream->write((const char*)buf_.data(), offset_);
+  request.SetBody(object_stream);
+
+  Aws::S3::Model::UploadPartOutcome outcome = client_->UploadPart(request);
+  if (outcome.IsSuccess()) {
+    LOG(INFO) << "upload part; part_number=" << parts_.size() + 1;
+
+    parts_.push_back(outcome.GetResult().GetETag());
+    offset_ = 0;
+    return std::error_code{};
+  } else {
+    // TODO(andydunstall): Return error
+    LOG(ERROR) << "failed to upload part: " << outcome.GetError().GetExceptionName();
+    return std::make_error_code(std::errc::io_error);
+  }
+}
+
+io::Result<std::unique_ptr<io::WriteFile>> WriteFile::Open(const std::string& bucket,
+                                                           const std::string& key,
+                                                           Aws::S3::S3Client* client) {
+  Aws::S3::Model::CreateMultipartUploadRequest request;
+  request.SetBucket(bucket);
+  request.SetKey(key);
+  Aws::Utils::Outcome<Aws::S3::Model::CreateMultipartUploadResult, Aws::S3::S3Error> outcome =
+      client->CreateMultipartUpload(request);
+  if (outcome.IsSuccess()) {
+    VLOG(2) << "created multipart upload; upload_id=" << outcome.GetResult().GetUploadId();
+    return std::make_unique<WriteFile>(bucket, key, outcome.GetResult().GetUploadId(), client);
+  } else {
+    LOG(ERROR) << "failed to create multipart upload: " << outcome.GetError().GetExceptionName();
+    return nonstd::make_unexpected(std::make_error_code(std::errc::io_error));
+  }
+}
+
+}  // namespace s3
+}  // namespace aws
+}  // namespace cloud
+}  // namespace util

--- a/util/cloud/aws/s3/write_file.h
+++ b/util/cloud/aws/s3/write_file.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <aws/s3/S3Client.h>
+
+#include <memory>
+#include <vector>
+
+#include "io/file.h"
+#include "io/io.h"
+
+namespace util {
+namespace cloud {
+namespace aws {
+namespace s3 {
+
+// Writes the given file to an object in S3.
+//
+// This multipart uploads, so we upload 8MB of the object at a time. This
+// avoids having to buffer the whole object and quickly recovers from
+// networking issues as we only have to retry a small portion of the object.
+class WriteFile : public io::WriteFile {
+ public:
+  WriteFile(const std::string& bucket, const std::string& key, const std::string& upload_id,
+            Aws::S3::S3Client* client);
+
+  // Writes bytes to the S3 object. This will either buffer internally or
+  // write a part to S3.
+  io::Result<size_t> WriteSome(const iovec* v, uint32_t len) override;
+
+  // Closes the object and completes the multipart upload. Therefore the object
+  // will not be uploaded unless Close is called.
+  std::error_code Close() override;
+
+  static io::Result<std::unique_ptr<io::WriteFile>> Open(const std::string& bucket,
+                                                         const std::string& key,
+                                                         Aws::S3::S3Client* client);
+
+ private:
+  std::error_code Upload();
+
+  std::string bucket_;
+
+  std::string key_;
+
+  std::string upload_id_;
+
+  // Etags of the uploaded parts.
+  std::vector<std::string> parts_;
+
+  size_t offset_ = 0;
+
+  std::vector<uint8_t> buf_;
+
+  Aws::S3::S3Client* client_;
+};
+
+}  // namespace s3
+}  // namespace aws
+}  // namespace cloud
+}  // namespace util

--- a/util/fibers/dns_resolve.cc
+++ b/util/fibers/dns_resolve.cc
@@ -152,6 +152,7 @@ void ProcessChannel(ares_channel channel, AresChannelState* state, DnsResolveCal
 }  // namespace
 
 error_code DnsResolve(string host, uint32_t wait_ms, char dest_ip[], ProactorBase* proactor) {
+  // TODO this fails - so its from the WRONG proactor thread
   DCHECK(ProactorBase::me() == proactor) << "must call from the proactor thread";
 
   VLOG(1) << "DnsResolveStart";

--- a/util/http/http_client.cc
+++ b/util/http/http_client.cc
@@ -66,7 +66,7 @@ std::error_code Client::Reconnect() {
 
   if (socket_) {
     error_code ec = socket_->Close();
-    LOG_IF(WARNING, !ec) << "Socket close failed: " << ec.message();
+    LOG_IF(WARNING, ec) << "Socket close failed: " << ec.message();
     socket_.reset();
   }
 

--- a/util/http/http_client.cc
+++ b/util/http/http_client.cc
@@ -46,6 +46,9 @@ Client::Client(ProactorBase* proactor) : proactor_(proactor) {
 }
 
 Client::~Client() {
+  if (socket_) {
+    socket_->Close();
+  }
 }
 
 std::error_code Client::Connect(string_view host, string_view service) {
@@ -119,7 +122,7 @@ auto Client::Send(Verb verb, string_view url, string_view body, Response* respon
 void Client::Shutdown() {
   if (socket_) {
     std::error_code ec = socket_->Shutdown(SHUT_RDWR);
-    LOG_IF(WARNING, !ec) << "Socket Shutdown failed: " << ec.message();
+    LOG_IF(WARNING, ec) << "Socket Shutdown failed: " << ec.message();
     socket_.reset();
   }
 }


### PR DESCRIPTION
Draft attempt at adding the [AWS C++ SDK](https://aws.amazon.com/sdk-for-cpp/) to Helio. Adding just to get feedback on switching to the AWS SDK, more work is needed to integrate properly...

The main parts here are `util/cloud/aws/http_client.cc` and `util/cloud/aws/s3/write_file.cc`.

This works uploading a 50GB snapshot from AWS in 2 minutes on a 16vCPU machine (~3GB per core) (can probably improve that, see 'tasks' below). (Dragonfly integration at https://github.com/dragonflydb/dragonfly/compare/main...andydunstall:dragonfly:feature/aws-sdk-poc)

# Why
The alternative to using the AWS SDK would be to implement our own AWS client (as Helio already does), though AWS clients are so complex and there are so many edge cases that to implement a client properly would be a ton of work. AWS recommends avoiding using the REST API directly. Using an SDK would also make it easier for users to configure the Helio AWS client as it would match how they would configure any other SDK (which is again a lot of work to implement ourselves given theres so many configuration options)

To make the existing Helio AWS client reliable we would need:
* A retry strategy with backoff and better error handling
* Signing payloads
* HTTP redirects
* Reloading expired credentials (from profile as well as EC2 metadata)
* Configuration
* Test coverage
* ...

# Issues
Since we use fibers we can't block the active thread with blocking system calls, sleeps, synchronisation etc.

AWS supports using a custom HTTP client (instead of the default cURL HTTP client) so we can the Helio HTTP client which will block the fiber but not the thread.

However there are other blocking calls that aren't as simple to override, including:
* Loading credentials and configuration from a local file
  * Note this may occur at arbitrary times due to refreshing credentials so isn't guaranteed to only happen on boot
* Synchronisation and threads sleeps, such as the default retry strategy will backoff for N seconds using an `std::condition_variable` and `std::mutex`

To using the SDK isn't trivial, though still seems like its worth exploring since implementing our own client would be hard

Adding our own HTTP client gets us 90% of the way there, but we'll likely need to add a few patches to integrate properly, such as avoiding blocking the thread in retry backoff and instead only blocking the fiber, and loading config and credentials from a local file without blocking.

As long we we don't block the thread for a long time, such as reading a small file in under 1ms, rather than sleeps or network calls which could be seconds, and only block when an S3 upload/download is happening to avoid affecting 'normal' operation, maybe this is acceptable for now...

# Extensions
## HTTP Client
By default the SDK uses cURL on Linux though we can extend the SDK with our own Helio HTTP client which blocks the fiber rather than the thread

We'll need to improve the existing HTTP client to handle redirects and handle connections better (where the HTTP client manages the connections rather than requiring explicitly connecting by the user), though we'd probably have to do that anyway even without using the SDK

Note we must make sure we also override `RetryRequestSleep`, which puts the thread to sleep when backoff off on a retry (which could be 10s of seconds). Its part of the HTTP client though not `virtual`, so we would need a small patch to the SDK to override this and use fiber blocking instead of thread blocking

## Logging
By default the SDK logs to a file, though we can add our own logger that uses glog to match Dragonfly and Helio, and use the same glog configuration

## Event Loop
By default the SDK starts a background event loop from [aws-c-io](https://github.com/awslabs/aws-c-io), though its not that clear what its used for (something to do with the `CRTHttpClient` or async API requests), though since we have our own HTTP client we can disable that

## Filesystem
The SDK uses synchronous file reads to read configuration and shared profile credentials. It doesn't seem to provide a way of extending the file calls.

Configuration is only read once on startup so probably isn't an issue, though shared profile credentials can be read once credentials expire. Its probably not a big issue though we should try to avoid it. The best option may be to fork the SDK to allow extending the filesystem reads/writes with out own Helio based API. Or we just accept a millisecond of thread blocking per day to reload credentials doesn't matter (and only when S3 is being used so won't affect 'normal' operation)... Or can disable loading credentials from the local filesystem (`~/.aws/credentials`) for now...

# S3
The SDK has a 'transfer manager', though that is built for uploading local files rather than our 'writer' interface, it also has some complex 'executor' event loop which we don't need. Therefore we can add our own uploader and downloader, similar to the existing Helio implementation, except we can use the SDK S3 client instead of making calls directly which makes the implementation relatively simple (ie use `s3::CreateMultipartUpload`, `s3::UploadPart` and `s3::CompleteMultipartUpload`)

# Tasks
This PR is just to get the SDK working though to make it 'production ready' we would need:

### CMake
So far I've just build and installed the SDK locally (which is why CI fails), though we would need to integrate that into Helio CMake properly.

We should also minimise what we need to build, such as S3 only and avoid CRT if we can.

### HTTP Client
The HTTP client needs work to be move reliable, including handling redirects (which is a requirement to use S3 as it may redirect to a different endpoint, see [docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingRouting.html)) and better connection management to avoid having to explicitly call `Connect`, but instead have the client connect as needed (and manage multiple connections). (Right now this PR just reconnects per request to avoid managing connections)

We also need request and connection timeouts.

We also probably need to add HTTPS support. There is a HTTPS client in Helio though its currently separate from the HTTP client. Maybe the HTTP client factory can just return the correct client as needed...

### File System
As described above, the SDK may make blocking system calls to read the local credentials and config. It will only load config once on startup so thats not an issue, though may reload local credentials again when they expire.

Given its likely less than 1ms to read the file and only happens when an S3 upload/download occurs so won't affect 'normal' operation, we may accept this for now. Or disable loading credentials from the local filesystem (so only support environment variables and EC2 metadata).

### Credentials
This PR so far only supports loading credentials from the environment. We need to support EC2 metadata, which should be fine as it should use the custom Helio HTTP client. We should to disable default credential providers like 'process', which forks and runs a separate process and pipes back the credentials or something.

### Optimise
Right now just to get something working as easily as possible, the HTTP client does more copies than it needs to when constructing a boost request from an AWS request, and an AWS response from a boost response, which should be avoidable.

We can benchmark the performance and resource usage using the SDK compared to the existing Helio implementation.

Can also look at tuning the part size etc.

(Running PR so far takes 2 minutes to take a 50GB snapshot on an `m5.4xlarge` (16 vCPU, 60GB memory))

### Testing
Since we're using the SDK we won't need to test too much, though should at least verify reconnects and retries work as expected, and the different supported credential providers work.

### Verify Non-Blocking
We a final check should verify the performance of Dragonfly is unaffected when no S3 operations are running, and compare the performance of Dragonfly while S3 uploads are happening

### Download Support
So far only added upload support, not download

### Dragonfly Integration
For testing added a hacky integration though this needs to be done properly