### PR TITLE
feat(aws): add https support

### DIFF
--- a/examples/s3_demo.cc
+++ b/examples/s3_demo.cc
@@ -22,6 +22,7 @@ ABSL_FLAG(std::string, key, "", "S3 file key");
 ABSL_FLAG(std::string, endpoint, "", "S3 endpoint");
 ABSL_FLAG(size_t, upload_size, 100 << 20, "Upload file size");
 ABSL_FLAG(size_t, chunk_size, 1024, "File chunk size");
+ABSL_FLAG(bool, https, false, "Whether to use HTTPS");
 ABSL_FLAG(bool, epoll, false, "Whether to use epoll instead of io_uring");
 
 std::shared_ptr<Aws::S3::S3Client> OpenS3Client() {
@@ -30,7 +31,8 @@ std::shared_ptr<Aws::S3::S3Client> OpenS3Client() {
   std::shared_ptr<Aws::Auth::AWSCredentialsProvider> credentials_provider =
       std::make_shared<util::aws::CredentialsProviderChain>();
   std::shared_ptr<Aws::S3::S3EndpointProviderBase> endpoint_provider =
-      std::make_shared<util::aws::S3EndpointProvider>(absl::GetFlag(FLAGS_endpoint));
+      std::make_shared<util::aws::S3EndpointProvider>(absl::GetFlag(FLAGS_endpoint),
+                                                      absl::GetFlag(FLAGS_https));
   return std::make_shared<Aws::S3::S3Client>(credentials_provider, endpoint_provider, s3_conf);
 }
 

--- a/util/aws/http_client.h
+++ b/util/aws/http_client.h
@@ -5,6 +5,7 @@
 
 #include <aws/core/client/ClientConfiguration.h>
 #include <aws/core/http/HttpClient.h>
+#include <openssl/ssl.h>
 
 #include <boost/beast/core/flat_buffer.hpp>
 
@@ -19,6 +20,14 @@ namespace aws {
 class HttpClient : public Aws::Http::HttpClient {
  public:
   HttpClient(const Aws::Client::ClientConfiguration& client_conf);
+
+  ~HttpClient();
+
+  HttpClient(const HttpClient&) = delete;
+  HttpClient& operator=(const HttpClient&) = delete;
+
+  HttpClient(HttpClient&&) = delete;
+  HttpClient& operator=(HttpClient&&) = delete;
 
   // Sends the given HTTP request to the server and returns a response.
   //
@@ -46,6 +55,8 @@ class HttpClient : public Aws::Http::HttpClient {
   std::error_code EnableKeepAlive(int fd) const;
 
   Aws::Client::ClientConfiguration client_conf_;
+
+  SSL_CTX* ctx_;
 };
 
 }  // namespace aws

--- a/util/aws/s3_endpoint_provider.h
+++ b/util/aws/s3_endpoint_provider.h
@@ -17,13 +17,15 @@ namespace aws {
 class S3EndpointProvider : public Aws::S3::S3EndpointProvider {
  public:
   // Configure a non-empty endpoint string to configure a custom endpoint.
-  S3EndpointProvider(const std::string& endpoint = "");
+  S3EndpointProvider(const std::string& endpoint = "", bool https = true);
 
   Aws::Endpoint::ResolveEndpointOutcome ResolveEndpoint(
       const Aws::Endpoint::EndpointParameters& endpoint_params) const override;
 
  private:
   std::string endpoint_;
+
+  bool https_;
 };
 
 }  // namespace aws

--- a/util/http/http_client.cc
+++ b/util/http/http_client.cc
@@ -136,7 +136,7 @@ SSL_CTX* TlsClient::CreateSslContext() {
     // Use the default locations for certificates. This means that any trusted
     // remote host by this local host, will be trusted as well.
     // see https://www.openssl.org/docs/man3.0/man1/openssl-verification-options.html
-    SSL_CTX_set_min_proto_version(ctx, TLS1_3_VERSION);
+    SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
 
     if (tls::SslProbeSetDefaultCALocation(ctx) != 0) {
       if (SSL_CTX_set_default_verify_paths(ctx) != 1) {


### PR DESCRIPTION
Adds HTTPS support to the AWS S3 client. (Will also add a dragonfly option to disable/enable HTTPS)

This uses the existing TLS client context and setup (since we write directly to the socket using `TlsClient` itself would be a pain so it just copies what it needs).

Since the HTTPS client is shared by multiple proactors, this still doesn't do connection caching. This has a bigger overhead with HTTPS though is still negligible compared to the 8MB chunk uploads and downloads so I don't think thats an issue.

(Can add connection caching if/when replacing the AWS SDK and add a separate HTTP client per proactor rather than a global shared client)

**TLS**
Not all AWS endpoints support TLS 1.3, though all support TLS 1.2, therefore updates the SSL context min version to 1.2 (down from 1.3)
  - Testing locally the S3 endpoints don't support 1.3
  - See https://aws.amazon.com/blogs/security/faster-aws-cloud-connections-with-tls-1-3/: *"Over 65% of AWS service API endpoints now support TLS version 1.3. We are continuing work to enable TLS version 1.3 on AWS service API endpoints globally."*